### PR TITLE
Add stdout option for idb output

### DIFF
--- a/RKSdcardTool.cpp
+++ b/RKSdcardTool.cpp
@@ -188,17 +188,23 @@ int main(int argc, char *argv[])
         }
     }
 
-    FILE *out = fopen(argv[2], "wb");
-    if (!out) {
-        perror("fopen");
-        delete[] idb;
-        delete[] loaderCodeBuffer;
-        delete[] loaderDataBuffer;
-        if (loaderHeadBuffer) delete[] loaderHeadBuffer;
-        return 1;
+    FILE *out;
+    if (strcmp(argv[2], "-") == 0) {
+        out = stdout;
+    } else {
+        out = fopen(argv[2], "wb");
+        if (!out) {
+            perror("fopen");
+            delete[] idb;
+            delete[] loaderCodeBuffer;
+            delete[] loaderDataBuffer;
+            if (loaderHeadBuffer) delete[] loaderHeadBuffer;
+            return 1;
+        }
     }
     fwrite(idb, 1, dwSectorNum * SECTOR_SIZE, out);
-    fclose(out);
+    if (out != stdout)
+        fclose(out);
 
     delete[] idb;
     delete[] loaderCodeBuffer;

--- a/Readme.txt
+++ b/Readme.txt
@@ -24,5 +24,6 @@ Usage
 ```
 
 The first argument is the Rockchip loader binary.  The second argument is
-the filename for the generated IDB.
+the filename for the generated IDB. Use `-` instead of a filename to write
+the IDB to standard output.
 


### PR DESCRIPTION
## Summary
- support writing the IDB to stdout by specifying `-` as the output file
- document new stdout option in `Readme.txt`

## Testing
- `cmake .`
- `make`
- `./rksdcardtool tests/rk356x_spl_loader_v1.19.113.bin - > /tmp/stdout.bin`


------
https://chatgpt.com/codex/tasks/task_e_686496dc478883209da80a3b20a9d916